### PR TITLE
Fix for correspond to servers belonging to domain

### DIFF
--- a/Example/Example/ServerDiscoveryViewController.swift
+++ b/Example/Example/ServerDiscoveryViewController.swift
@@ -76,7 +76,7 @@ extension ServerDiscoveryViewController: UITableViewDataSource {
 
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         let svr = self.servers[indexPath.row]
-        let smbServer = SMBServer(hostname: svr.name, ipAddress: svr.ipAddress)
+        let smbServer = SMBServer(hostname: svr.name, ipAddress: svr.ipAddress, domain: svr.group)
 
         self.tableView.deselectRow(at: indexPath, animated: true)
         let vc = UIStoryboard.authViewController(server: smbServer)

--- a/Sources/NetBIOSNameServiceEntry.swift
+++ b/Sources/NetBIOSNameServiceEntry.swift
@@ -74,7 +74,7 @@ public struct NetBIOSNameServiceEntry {
     }
 
     public var smbServer: SMBServer {
-        return SMBServer(hostname: self.name, ipAddress: self.ipAddress)
+        return SMBServer(hostname: self.name, ipAddress: self.ipAddress, domain: self.group)
     }
 }
 

--- a/Sources/SMBServer.swift
+++ b/Sources/SMBServer.swift
@@ -11,15 +11,18 @@ import Foundation
 public struct SMBServer {
     public let hostname: String
     public let ipAddress: UInt32
+    public let domain: String
 
-    public init(hostname: String, ipAddress: UInt32) {
+    public init(hostname: String, ipAddress: UInt32, domain: String) {
         self.hostname = hostname
         self.ipAddress = ipAddress
+        self.domain = domain
     }
 
     // fails initiation if ipAddress lookup fails
-    public init?(hostname: String) {
+    public init?(hostname: String, domain: String = "") {
         self.hostname = hostname
+        self.domain = domain
         let ns = NetBIOSNameService()
         if let addr = ns.resolveIPAddress(forName: self.hostname, ofType: .fileServer) {
             self.ipAddress = addr

--- a/Sources/SMBSession.swift
+++ b/Sources/SMBSession.swift
@@ -255,7 +255,7 @@ public class SMBSession {
         }
 
         smb_session_set_creds(self.rawSession,
-                              self.server.hostname.cString(using: .utf8),
+                              self.server.domain.cString(using: .utf8),
                               self.credentials.userName.cString(using: .utf8),
                               self.credentials.password.cString(using: .utf8))
         if smb_session_login(self.rawSession) != 0 {


### PR DESCRIPTION
@sfaxon 
A phenomenon occurred in which a file list could not be acquired for a server belonging to a domain.

Even if the smb_session_login function is different in ID / PASS, it will succeed if you authenticate against the public directory.

At this time, when confirming the user with the smb_session_is_guest function, we found that the guest account refers to the directory.

I noticed that the second argument to the smb_session_set_creds function is a domain, not a host name.

After changing the information to be set as the second argument of the smb_session_set_creds function to the domain, we succeeded in getting the list of the files.

Since there seems to be another person in need, if you are satisfied with the change content, can you merge it?