### PR TITLE
Adding swift version to podspec

### DIFF
--- a/SMBClient.podspec
+++ b/SMBClient.podspec
@@ -7,22 +7,16 @@
 #
 
 Pod::Spec.new do |s|
-  s.name             = 'SMBClient'
-  s.version          = '0.0.8'
-  s.summary          = 'SMBClient is simple SMB client for iOS apps. It allows connecting to SMB devices.'
-
-  s.homepage         = "https://github.com/filmicpro/SMBClient"
-  s.license          = { :type => 'MIT', :file => 'LICENSE' }
-  s.author           = { 'Seth Faxon' => 'seth@filmicpro.com' }
-  s.source           = { :git => "https://github.com/filmicpro/SMBClient.git", :tag => "#{s.version}" }
-
+  s.name = 'SMBClient'
+  s.version = '0.0.8'
+  s.summary = 'SMBClient is simple SMB client for iOS apps. It allows connecting to SMB devices.'
+  s.homepage = "https://github.com/filmicpro/SMBClient"
+  s.license = { :type => 'MIT', :file => 'LICENSE' }
+  s.author = { 'Seth Faxon' => 'seth@filmicpro.com' }
+  s.source = { :git => "https://github.com/filmicpro/SMBClient.git", :tag => "#{s.version}" }
   s.ios.deployment_target = '10.0'
-
+  s.swift_version = '4.0'
   s.source_files  = ["Sources/**/*.swift", "libdsm/**/*.h", "libdsm/**/*.modulemap"]
-  # s.xcconfig = {
-  #   'HEADER_SEARCH_PATHS' => '/Users/sfaxon/src/SMBClient/libdsm/include/bdsm',
-  #   'SWIFT_INCLUDE_PATHS' => '/Users/sfaxon/src/SMBClient/libdsm'
-  # }
   s.xcconfig = {
     'HEADER_SEARCH_PATHS' => '$(PODS_TARGET_SRCROOT)/libdsm/include/bdsm',
     'SWIFT_INCLUDE_PATHS' => '$(PODS_TARGET_SRCROOT)/libdsm'
@@ -30,5 +24,4 @@ Pod::Spec.new do |s|
   s.preserve_paths = 'libdsm/*'
   s.vendored_libraries = 'libdsm/libdsm.a', 'libdsm/libtasn1.a'
   s.library = 'iconv'
-
 end


### PR DESCRIPTION
This PR adds the `swift_version` to the podspec to make sure cocoapod installations know which version of Swift to use. Swift 4.2 has warnings and Swift 5 fails due to changes in the mutable pointer's `allocate` and `deallocate` methods